### PR TITLE
add maildir support to the mailbox detection

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -41,7 +41,7 @@ let mark_command args =
   if args = [] then
     mark_message db (read_single_msg stdin)
   else
-    List.iter (fun f -> mbox_file_iter f (mark_message db)) args
+    List.iter (fun f -> mbox_iter f (mark_message db)) args
 
 let add_command args =
   let db =
@@ -60,7 +60,7 @@ let add_command args =
     | "-good" :: rem ->
         is_spam := false; parse_args rem
     | f :: rem ->
-        mbox_file_iter f (add_message db !verbose !is_spam);
+        mbox_iter f (add_message db !verbose !is_spam);
         processed := true;
         parse_args rem
     | [] ->
@@ -122,7 +122,7 @@ let test_command args =
     | "-max" :: [] ->
         raise(Usage("no argument to -max"))
     | f :: rem ->
-        mbox_file_iter f (test_message db !low !high f);
+        mbox_iter f (test_message db !low !high f);
         parse_args rem
     | [] -> ()
   in parse_args args
@@ -134,7 +134,7 @@ let stat_command args =
     and num_good = ref 0
     and num_spam = ref 0
     and num_unknown = ref 0 in
-    mbox_file_iter f
+    mbox_iter f
       (fun s ->
         incr num_msgs;
         match stat_message db s with
@@ -158,7 +158,7 @@ let words_command args =
   else
     List.iter
       (fun f ->
-        mbox_file_iter f
+        mbox_iter f
           (fun msg ->
             print_string "----------------------------------------\n";
             wordsplit_message db msg))

--- a/mbox.mli
+++ b/mbox.mli
@@ -35,5 +35,14 @@ val mbox_channel_iter: in_channel -> (string -> unit) -> unit
   (** [mbox_channel_iter ic fn] reads messages from the input channel
       [ic], and applies [fn] in turn to each message. *)
 
+val maildir_iter: string -> (string -> unit) -> unit
+  (** [maildir_iter dirname fn] reads messages from the maildir
+      [<dirname>/cur], and applies [fn] in turn to each message. *)
+
+val mbox_iter: string -> (string -> unit) -> unit
+  (** [mbox_iter name fn] runs {!maildir_iter} if [name] is a Maildir
+      format directory (i.e. [<name>/cur] is a directory), and
+      otherwise opens [name] as an mbox-format file. *)
+
 val read_single_msg: in_channel -> string
   (** Read one message from the given channel, up to end of file *)


### PR DESCRIPTION
I've been a happy user of spamoracle for many many years (thank you!) and in my christmas email spring-clean realised that I had this patch lying around for quite some time.

It adds support for Maildir format directories (where each email is a single file), and makes it far faster to scan large directories without having to fork a copy of spamoracle for each individual message.  I've run it on my spam/ham corpus of around 3 million messages in various Maildirs without issue. The CLI is unchanged -- the only difference is that if a Maildir filename is detected (i.e. `<name>/cur` exists and is a directory), then Maildir mode is used instead of mbox mode.

If you'd like this upstream, I can add documentation patches as well. The implementation could be optimised more (by not allocating a 50k buffer per file, as it reuses the mbox logic), but it's also plenty fast enough already. 